### PR TITLE
feat: yield before attempting to report flakey test

### DIFF
--- a/pytest_sentry.py
+++ b/pytest_sentry.py
@@ -69,7 +69,7 @@ def pytest_load_initial_conftests(early_config, parser, args):
 @pytest.hookimpl(tryfirst=True, hookwrapper=True)
 def pytest_runtest_makereport(item, call):
     yield
-    
+
     if call.when == "call":
         hub = _resolve_hub_marker_value(item.get_closest_marker("sentry_client"))
         integration = hub.get_integration(PytestIntegration)

--- a/pytest_sentry.py
+++ b/pytest_sentry.py
@@ -68,6 +68,8 @@ def pytest_load_initial_conftests(early_config, parser, args):
 
 @pytest.hookimpl(tryfirst=True, hookwrapper=True)
 def pytest_runtest_makereport(item, call):
+    yield
+    
     if call.when == "call":
         hub = _resolve_hub_marker_value(item.get_closest_marker("sentry_client"))
         integration = hub.get_integration(PytestIntegration)
@@ -81,7 +83,6 @@ def pytest_runtest_makereport(item, call):
 
             if (cur_exc_chain and call.excinfo is None) or integration.always_report:
                 _report_flaky_test(hub, item, call, cur_exc_chain)
-    yield
 
 
 def _get_default_hub():


### PR DESCRIPTION
At least in the sentry codebase, `call.excinfo` is always `None` until we yield to other hooks.